### PR TITLE
silentjoinleave permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,9 @@ This feature is related to [this issue](https://github.com/kraftwerk28/spigot-tg
 | Command | Description |
 |:-------:|:------------|
 | `tgbridge_reload` | Reload plugin configuration w/o need to stop the server. Works only through server console |
+
+## Permissions
+
+|         Permission          | Description                                                                                                                           |
+| :-------------------------: | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `tg-bridge.silentjoinleave` | When set to **true** the bot won't send join and leave messages for that player. It will also be hidden from the **/online** command. |

--- a/src/main/kotlin/org/kraftwerk28/spigot_tg_bridge/EventHandler.kt
+++ b/src/main/kotlin/org/kraftwerk28/spigot_tg_bridge/EventHandler.kt
@@ -39,7 +39,7 @@ class EventHandler(
         val player = event.player
         val hasPermission = player.hasPermission("tg-bridge.silentjoinleave")
         if (hasPermission) return
-        val username = event.player.displayName.fullEscape()
+        val username = player.displayName.fullEscape()
         val text = config.leaveString.replace("%username%", username)
         sendMessage(text)
     }
@@ -47,6 +47,8 @@ class EventHandler(
     @EventHandler
     fun onPlayerDied(event: PlayerDeathEvent) {
         if (!config.logDeath) return
+        val hasPermission = event.entity.hasPermission("tg-bridge.silentjoinleave")
+        if (hasPermission) return
         event.deathMessage?.let {
             val username = event.entity.displayName.fullEscape()
             val text = it.replace(username, "<i>$username</i>")
@@ -57,9 +59,12 @@ class EventHandler(
     @EventHandler
     fun onPlayerAsleep(event: PlayerBedEnterEvent) {
         if (!config.logPlayerAsleep) return
+        val player = event.player
+        val hasPermission = player.hasPermission("tg-bridge.silentjoinleave")
+        if (hasPermission) return
         if (event.bedEnterResult != PlayerBedEnterEvent.BedEnterResult.OK)
             return
-        val text = "<i>${event.player.displayName}</i> fell asleep."
+        val text = "<i>${player.displayName}</i> fell asleep."
         sendMessage(text)
     }
 

--- a/src/main/kotlin/org/kraftwerk28/spigot_tg_bridge/EventHandler.kt
+++ b/src/main/kotlin/org/kraftwerk28/spigot_tg_bridge/EventHandler.kt
@@ -25,7 +25,10 @@ class EventHandler(
     @EventHandler
     fun onPlayerJoin(event: PlayerJoinEvent) {
         if (!config.logJoinLeave) return
-        val username = event.player.displayName.fullEscape()
+        val player = event.player
+        val hasPermission = player.hasPermission("tg-bridge.silentjoinleave")
+        if (hasPermission) return
+        val username = player.displayName.fullEscape()
         val text = config.joinString.replace("%username%", username)
         sendMessage(text)
     }
@@ -33,6 +36,9 @@ class EventHandler(
     @EventHandler
     fun onPlayerLeave(event: PlayerQuitEvent) {
         if (!config.logJoinLeave) return
+        val player = event.player
+        val hasPermission = player.hasPermission("tg-bridge.silentjoinleave")
+        if (hasPermission) return
         val username = event.player.displayName.fullEscape()
         val text = config.leaveString.replace("%username%", username)
         sendMessage(text)

--- a/src/main/kotlin/org/kraftwerk28/spigot_tg_bridge/TgBot.kt
+++ b/src/main/kotlin/org/kraftwerk28/spigot_tg_bridge/TgBot.kt
@@ -178,13 +178,13 @@ class TgBot(
         if (!config.allowedChats.contains(msg.chat.id)) {
             return
         }
-        val playerList = plugin.server.onlinePlayers
-        val playerStr = plugin.server
-            .onlinePlayers
+        // Filter out players with the 'tg-bridge.silentjoinleave' permission
+        val visiblePlayers = plugin.server.onlinePlayers.filter { !it.hasPermission("tg-bridge.silentjoinleave") }
+        val playerStr = visiblePlayers
             .mapIndexed { i, s -> "${i + 1}. ${s.displayName.fullEscape()}" }
             .joinToString("\n")
         val text =
-            if (playerList.isNotEmpty()) "${config.onlineString}:\n$playerStr"
+            if (visiblePlayers.isNotEmpty()) "${config.onlineString}:\n$playerStr"
             else config.nobodyOnlineString
         api.sendMessage(msg.chat.id, text, replyToMessageId = msg.messageId)
     }


### PR DESCRIPTION
This pull request implements a new permission, `tg-bridge.silentjoinleave`, which prevents the bot from sending join and leave messages for specific players. Additionally, it hides these players from the `online` command.

### Summary of Changes
- Added `tg-bridge.silentjoinleave` permission.
- Updated the logic in the bot to check this permission before sending join/leave messages.
- Modified the `online` command to exclude players with this permission.

My use case: Sometimes, I like to join my server in vanish mode so I can spectate players without them knowing. However, notifying them on Telegram whenever I join kinda defeats the purpose. I would set this permission to true and join the server. Set it back to false when I want other players to know I'm around.

**Edit:** Now that I think about it, perhaps it should also prevent sending messages on the other event handlers if the player has the permission (sleep, die and chat).